### PR TITLE
Fix panic for "/" route

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -263,7 +263,7 @@ func (wh *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(wh.route) != 1 && wh.route[:1] == "/" {
+	if len(wh.route) >= 1 && wh.route[:1] == "/" {
 		wh.route = wh.route[1:]
 	}
 

--- a/waggy_test.go
+++ b/waggy_test.go
@@ -263,3 +263,13 @@ func TestServe_Handler(t *testing.T) {
 	// Assert
 	assert.Error(t, err)
 }
+
+func TestEmptyRoute(t *testing.T) {
+	handler := InitHandlerWithRoute("/", nil)
+	handler.WithMethodHandler(http.MethodGet, func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprintln(writer, "Don't panic! 🐿️")
+	})
+	r, _ := http.NewRequest(http.MethodGet, resources.TestRoutePathParamGoodbye, nil)
+	wr := httptest.NewRecorder()
+	handler.ServeHTTP(wr, r)
+}


### PR DESCRIPTION
Hey I've noticed waggy panics for the case presented in `TestEmptyRoute`, perhaps we don't have to sanitize `wh.route` again since `InitHandlerWithRoute`  takes care of it already?