### PR TITLE
Middleware

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -2,4 +2,4 @@ package middleware
 
 import "net/http"
 
-type MiddleWare func(handler http.Handler)
+type MiddleWare func(handler http.Handler) http.Handler

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,0 +1,5 @@
+package middleware
+
+import "net/http"
+
+type MiddleWare func(handler http.Handler)

--- a/router.go
+++ b/router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/syke99/waggy/internal/json"
+	"github.com/syke99/waggy/middleware"
 	"net/http"
 	"os"
 	"strconv"
@@ -23,6 +24,7 @@ type Router struct {
 	noRoute      WaggyError
 	noRouteFunc  http.HandlerFunc
 	FullServer   bool
+	middleWare   []middleware.MiddleWare
 }
 
 // InitRouter initializes a new Router and returns a pointer
@@ -118,6 +120,19 @@ func (wr *Router) WithNoRouteHandler(fn http.HandlerFunc) *Router {
 func (wr *Router) Logger() *Logger {
 	return wr.logger
 }
+
+//
+//func (wr *Router) Use(middleWare ...middleware.MiddleWare) {
+//	for _, mw := range middleWare {
+//		wr.middleWare = append(wr.middleWare, mw)
+//	}
+//}
+//
+//func (wr *Router) passThroughMiddleWare(w http.ResponseWriter, r *http.Request) {
+//	for _, mw := range wr.middleWare {
+//		mw(wr.ServeHTTP(w, r))
+//	}
+//}
 
 // ServeHTTP satisfies the http.Handler interface and calls the stored
 // handler at the route of the incoming HTTP request

--- a/waggy.go
+++ b/waggy.go
@@ -3,6 +3,7 @@ package waggy
 import (
 	"errors"
 	"fmt"
+	"github.com/syke99/waggy/middleware"
 	"io"
 	"net/http"
 	"net/http/cgi"
@@ -134,4 +135,14 @@ func ServeFile(w http.ResponseWriter, contentType string, filePath string) {
 		w.Header().Set("content-type", "application/problem+json")
 		fmt.Fprint(w, errJSON)
 	}
+}
+
+func serveThroughMiddleWare(middle []middleware.MiddleWare, handler http.HandlerFunc, w http.ResponseWriter, r *http.Request) {
+	for _, mw := range middle {
+		//handler = mw(handler).(http.HandlerFunc)
+		handler = mw(handler).ServeHTTP
+	}
+
+	handler.ServeHTTP(w, r)
+	return
 }


### PR DESCRIPTION
This PR allows users to create and use custom Middleware handlers that Waggy will pass the request through. 

- You can set Router-wide Middleware that every request processed by the Router will be passed through by using `*Router.Use(middleware ...middleware.Middleware)`

- You can also set Middleware for specific Handlers that will only be used when that Handler processes the request by using `*Handler.Use(middleware ...middleware.Middleware)`