### PR TITLE
Middleware

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -32,9 +32,9 @@ type Handler struct {
 	middleWare           []middleware.MiddleWare
 }
 
-// InitHandler initialized a new Handler and returns
+// NewHandler initialized a new Handler and returns
 // a pointer to it
-func InitHandler(cgi *FullServer) *Handler {
+func NewHandler(cgi *FullServer) *Handler {
 	var o bool
 	var err error
 
@@ -61,10 +61,10 @@ func InitHandler(cgi *FullServer) *Handler {
 	return &w
 }
 
-// InitHandlerWithRoute initialized a new Handler with the provided
+// NewHandlerWithRoute initialized a new Handler with the provided
 // route and returns a pointer to it. It is intended to be used whenever
 // only compiling an individual *Handler instead of a full *Router
-func InitHandlerWithRoute(route string, cgi *FullServer) *Handler {
+func NewHandlerWithRoute(route string, cgi *FullServer) *Handler {
 	if len(route) >= 1 && route[:1] == "/" {
 		route = route[1:]
 	}
@@ -246,6 +246,10 @@ func (wh *Handler) Use(middleWare ...middleware.MiddleWare) {
 	}
 }
 
+func (wh *Handler) Middleware() []middleware.MiddleWare {
+	return wh.middleWare
+}
+
 // ServeHTTP serves the route
 func (wh *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if _, ok := wh.restrictedMethods[r.Method]; ok {
@@ -379,11 +383,6 @@ func (wh *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.Clone(ctx)
 
 	handler, _ := wh.handlerMap[r.Method]
-
-	if len(wh.middleWare) != 0 {
-		serveThroughMiddleWare(wh.middleWare, handler, w, r)
-		return
-	}
 
 	handler(w, r)
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -19,9 +19,9 @@ func TestAllHTTPMethods(t *testing.T) {
 	assert.Equal(t, "ALL", all)
 }
 
-func TestInitHandler(t *testing.T) {
+func TestNewHandler(t *testing.T) {
 	// Act
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Assert
 	assert.IsType(t, &Handler{}, w)
@@ -32,9 +32,9 @@ func TestInitHandler(t *testing.T) {
 	assert.IsType(t, map[string]http.HandlerFunc{}, w.handlerMap)
 }
 
-func TestInitHandlerWithRoute(t *testing.T) {
+func TestNewHandlerWithRoute(t *testing.T) {
 	// Act
-	w := InitHandlerWithRoute(resources.TestRoute, nil)
+	w := NewHandlerWithRoute(resources.TestRoute, nil)
 
 	// Assert
 	assert.IsType(t, &Handler{}, w)
@@ -47,7 +47,7 @@ func TestInitHandlerWithRoute(t *testing.T) {
 
 func TestHandler_WithDefaultResponse(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Act
 	w.WithDefaultResponse(resources.TestContentType, []byte(resources.HelloWorld))
@@ -64,7 +64,7 @@ func TestHandler_WithDefaultResponse(t *testing.T) {
 
 func TestHandler_WithDefaultErrorResponse(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 	testErr := WaggyError{
 		Type:   resources.TestRoute,
 		Title:  "",
@@ -96,7 +96,7 @@ func TestHandler_MethodHandler(t *testing.T) {
 	goodbyeHandler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, resources.Goodbye)
 	}
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Act
 	w.WithMethodHandler(http.MethodGet, helloHandler)
@@ -122,7 +122,7 @@ func TestHandler_MethodHandler(t *testing.T) {
 
 func TestHandler_RestrictMethods(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Act
 	w = w.RestrictMethods(http.MethodGet,
@@ -144,7 +144,7 @@ func TestHandler_RestrictMethods(t *testing.T) {
 
 func TestHandler_RestrictMethods_NotHTTPMethod(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 	test := "this isn't an http method"
 
 	// Act
@@ -159,7 +159,7 @@ func TestHandler_RestrictMethods_NotHTTPMethod(t *testing.T) {
 
 func TestHandler_WithRestrictedMethodHandler(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 	testHandler := func(w http.ResponseWriter, r *http.Request) {}
 
 	// Act
@@ -171,7 +171,7 @@ func TestHandler_WithRestrictedMethodHandler(t *testing.T) {
 
 func TestHandler_WithRestrictedMethodHandler_NoHandler(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Act
 	w.WithRestrictedMethodHandler(nil)
@@ -186,7 +186,7 @@ func TestHandler_WithLogger(t *testing.T) {
 	testLogLevel := Info
 	testLogger := NewLogger(testLogLevel, testLog)
 
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Act
 	w.WithLogger(testLogger, nil)
@@ -203,14 +203,14 @@ func TestHandler_WithLogger(t *testing.T) {
 
 func TestHandler_WithLogger_ParentOverride(t *testing.T) {
 	// Assert
-	r := InitRouter(nil).
+	r := NewRouter(nil).
 		WithDefaultLogger()
 
 	testLog := resources.TestLogFile
 	testLogLevel := Info
 	testLogger := NewLogger(testLogLevel, testLog)
 
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Act
 	w.WithLogger(testLogger, OverrideParentLogger())
@@ -229,7 +229,7 @@ func TestHandler_WithLogger_ParentOverride(t *testing.T) {
 
 func TestHandler_WithDefaultLogger(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Act
 	w.WithDefaultLogger()
@@ -250,7 +250,7 @@ func TestHandler_Logger(t *testing.T) {
 	testLogLevel := Info
 	testLogger := NewLogger(testLogLevel, testLog)
 
-	w := InitHandler(nil).
+	w := NewHandler(nil).
 		WithLogger(testLogger, nil)
 
 	// Act
@@ -268,14 +268,14 @@ func TestHandler_Logger(t *testing.T) {
 
 func TestHandler_Logger_Inherited_NoParentOverride(t *testing.T) {
 	// Assert
-	r := InitRouter(nil).
+	r := NewRouter(nil).
 		WithDefaultLogger()
 
 	testLog := resources.TestLogFile
 	testLogLevel := Info
 	testLogger := NewLogger(testLogLevel, testLog)
 
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	w.WithLogger(testLogger, nil)
 
@@ -296,14 +296,14 @@ func TestHandler_Logger_Inherited_NoParentOverride(t *testing.T) {
 
 func TestHandler_Logger_Inherited_ParentOverride(t *testing.T) {
 	// Assert
-	r := InitRouter(nil).
+	r := NewRouter(nil).
 		WithDefaultLogger()
 
 	testLog := resources.TestLogFile
 	testLogLevel := Info
 	testLogger := NewLogger(testLogLevel, testLog)
 
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	w.WithLogger(testLogger, OverrideParentLogger())
 
@@ -324,7 +324,7 @@ func TestHandler_Logger_Inherited_ParentOverride(t *testing.T) {
 
 func TestHandler_ServeHTTP_RestrictedMethod_NoHandler(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil).
+	w := NewHandler(nil).
 		RestrictMethods(http.MethodGet)
 
 	r, _ := http.NewRequest(http.MethodGet, resources.TestRoute, nil)
@@ -346,7 +346,7 @@ func TestHandler_ServeHTTP_RestrictedMethod_Handler(t *testing.T) {
 		fmt.Fprintln(w, "this method isn't allowed, sorry")
 	}
 
-	w := InitHandler(nil).
+	w := NewHandler(nil).
 		RestrictMethods(http.MethodGet).
 		WithRestrictedMethodHandler(noRouteHandler)
 
@@ -372,7 +372,7 @@ func TestHandler_ServeHTTP_MethodGet(t *testing.T) {
 		fmt.Fprintln(w, resources.Goodbye)
 	}
 
-	w := InitHandlerWithRoute(resources.TestRoute, nil)
+	w := NewHandlerWithRoute(resources.TestRoute, nil)
 
 	w.WithMethodHandler(http.MethodGet, helloHandler)
 	w.WithMethodHandler(http.MethodDelete, goodbyeHandler)
@@ -429,7 +429,7 @@ func TestHandler_ServeHTTP_MethodDelete(t *testing.T) {
 		fmt.Fprintln(w, resources.Goodbye)
 	}
 
-	w := InitHandlerWithRoute(resources.TestRoute, nil)
+	w := NewHandlerWithRoute(resources.TestRoute, nil)
 
 	w.WithMethodHandler(http.MethodGet, helloHandler)
 	w.WithMethodHandler(http.MethodDelete, goodbyeHandler)

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,3 +3,11 @@ package middleware
 import "net/http"
 
 type MiddleWare func(handler http.Handler) http.Handler
+
+func PassThroughMiddleWare(middle []MiddleWare, handler http.HandlerFunc) http.HandlerFunc {
+	for _, mw := range middle {
+		handler = mw(handler).ServeHTTP
+	}
+
+	return handler
+}

--- a/router.go
+++ b/router.go
@@ -27,9 +27,9 @@ type Router struct {
 	middleWare   []middleware.MiddleWare
 }
 
-// InitRouter initializes a new Router and returns a pointer
+// NewRouter initializes a new Router and returns a pointer
 // to it
-func InitRouter(cgi *FullServer) *Router {
+func NewRouter(cgi *FullServer) *Router {
 	var o bool
 	var err error
 
@@ -126,6 +126,10 @@ func (wr *Router) Use(middleWare ...middleware.MiddleWare) {
 	for _, mw := range middleWare {
 		wr.middleWare = append(wr.middleWare, mw)
 	}
+}
+
+func (wr *Router) Middleware() []middleware.MiddleWare {
+	return wr.middleWare
 }
 
 // ServeHTTP satisfies the http.Handler interface and calls the stored
@@ -226,11 +230,6 @@ func (wr *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if handler == nil {
 			wr.noRouteResponse(w, r)
 		}
-	}
-
-	if len(wr.middleWare) != 0 {
-		serveThroughMiddleWare(wr.middleWare, handler.ServeHTTP, w, r)
-		return
 	}
 
 	handler.ServeHTTP(w, r)

--- a/router_test.go
+++ b/router_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/syke99/waggy/internal/resources"
 )
 
-func TestInitRouter(t *testing.T) {
+func TestNewRouter(t *testing.T) {
 	// Act
-	w := InitRouter(nil)
+	w := NewRouter(nil)
 
 	// Assert
 	assert.IsType(t, &Router{}, w)
@@ -21,10 +21,10 @@ func TestInitRouter(t *testing.T) {
 	assert.Equal(t, 0, len(w.router))
 }
 
-func TestInitRouter_Flg_Parsable(t *testing.T) {
+func TestNewRouter_Flg_Parsable(t *testing.T) {
 	// Act
 	var flg FullServer = "1"
-	w := InitRouter(&flg)
+	w := NewRouter(&flg)
 
 	// Assert
 	assert.IsType(t, &Router{}, w)
@@ -33,10 +33,10 @@ func TestInitRouter_Flg_Parsable(t *testing.T) {
 	assert.True(t, w.FullServer)
 }
 
-func TestInitRouter_Flg_NotParsable(t *testing.T) {
+func TestNewRouter_Flg_NotParsable(t *testing.T) {
 	// Act
 	var flg FullServer = "adsf"
-	w := InitRouter(&flg)
+	w := NewRouter(&flg)
 
 	// Assert
 	assert.IsType(t, &Router{}, w)
@@ -47,10 +47,10 @@ func TestInitRouter_Flg_NotParsable(t *testing.T) {
 
 func TestRouter_Handle(t *testing.T) {
 	// Arrange
-	w := InitRouter(nil)
+	w := NewRouter(nil)
 
-	helloHandler := InitHandler(nil)
-	goodbyeHandler := InitHandler(nil)
+	helloHandler := NewHandler(nil)
+	goodbyeHandler := NewHandler(nil)
 
 	// Act
 	w.Handle("/hello", helloHandler)
@@ -63,7 +63,7 @@ func TestRouter_Handle(t *testing.T) {
 
 func TestRouter_WithLogger(t *testing.T) {
 	// Arrange
-	w := InitRouter(nil)
+	w := NewRouter(nil)
 
 	testLog := resources.TestLogFile
 	testLogLevel := Info
@@ -84,7 +84,7 @@ func TestRouter_WithLogger(t *testing.T) {
 
 func TestRouter_WithDefaultLogger(t *testing.T) {
 	// Arrange
-	w := InitRouter(nil)
+	w := NewRouter(nil)
 
 	// Act
 	w.WithDefaultLogger()
@@ -105,7 +105,7 @@ func TestRouter_Logger(t *testing.T) {
 	testLogLevel := Info
 	testLogger := NewLogger(testLogLevel, testLog)
 
-	w := InitRouter(nil).
+	w := NewRouter(nil).
 		WithLogger(testLogger)
 
 	// Act
@@ -123,7 +123,7 @@ func TestRouter_Logger(t *testing.T) {
 
 func TestRouter_Logger_Default(t *testing.T) {
 	// Arrange
-	w := InitRouter(nil).
+	w := NewRouter(nil).
 		WithDefaultLogger()
 
 	// Act
@@ -145,13 +145,13 @@ func TestRouter_ServeHTTP_NoBaseRoute(t *testing.T) {
 		fmt.Fprintln(w, resources.Goodbye)
 	}
 
-	wr := InitRouter(nil).WithNoRouteHandler(goodbyeHandler)
+	wr := NewRouter(nil).WithNoRouteHandler(goodbyeHandler)
 
 	helloHandler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, resources.Hello)
 	}
 
-	wh := InitHandler(nil).
+	wh := NewHandler(nil).
 		WithMethodHandler(http.MethodGet, helloHandler)
 
 	wr.Handle(resources.TestRoute, wh)
@@ -175,16 +175,16 @@ func TestRouter_ServeHTTP_BaseRoute(t *testing.T) {
 		fmt.Fprintln(w, resources.Goodbye)
 	}
 
-	wr := InitRouter(nil)
+	wr := NewRouter(nil)
 
 	helloHandler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, resources.Hello)
 	}
 
-	wh := InitHandler(nil).
+	wh := NewHandler(nil).
 		WithMethodHandler(http.MethodGet, helloHandler)
 
-	wh2 := InitHandler(nil).WithMethodHandler(http.MethodGet, goodbyeHandler)
+	wh2 := NewHandler(nil).WithMethodHandler(http.MethodGet, goodbyeHandler)
 
 	wr.Handle(resources.TestRoute, wh).Handle("/", wh2)
 
@@ -203,13 +203,13 @@ func TestRouter_ServeHTTP_BaseRoute(t *testing.T) {
 
 func TestRouter_ServeHTTP_MethodGet(t *testing.T) {
 	// Arrange
-	wr := InitRouter(nil)
+	wr := NewRouter(nil)
 
 	helloHandler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, resources.Hello)
 	}
 
-	wh := InitHandler(nil).
+	wh := NewHandler(nil).
 		WithMethodHandler(http.MethodGet, helloHandler)
 
 	wr.Handle(resources.TestRoute, wh)
@@ -229,13 +229,13 @@ func TestRouter_ServeHTTP_MethodGet(t *testing.T) {
 
 func TestRouter_ServeHTTP_MethodDelete(t *testing.T) {
 	// Arrange
-	wr := InitRouter(nil)
+	wr := NewRouter(nil)
 
 	goodbyeHandler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, resources.Goodbye)
 	}
 
-	wh := InitHandler(nil).
+	wh := NewHandler(nil).
 		WithMethodHandler(http.MethodDelete, goodbyeHandler)
 
 	wr.Handle(resources.TestRoute, wh)
@@ -255,7 +255,7 @@ func TestRouter_ServeHTTP_MethodDelete(t *testing.T) {
 
 func TestRouter_Walk(t *testing.T) {
 	// Arrange
-	wr := InitRouter(nil)
+	wr := NewRouter(nil)
 
 	helloHandler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, resources.Hello)
@@ -265,12 +265,12 @@ func TestRouter_Walk(t *testing.T) {
 		fmt.Fprintln(w, resources.Goodbye)
 	}
 
-	wh := InitHandler(nil).
+	wh := NewHandler(nil).
 		WithMethodHandler(http.MethodDelete, goodbyeHandler)
 
 	wr.Handle(resources.TestRoute, wh)
 
-	wh2 := InitHandler(nil).
+	wh2 := NewHandler(nil).
 		WithMethodHandler(http.MethodGet, helloHandler)
 
 	wr.Handle(resources.TestRouteTwo, wh2)
@@ -300,7 +300,7 @@ func TestRouter_Walk(t *testing.T) {
 
 func TestRouter_Walk_Error(t *testing.T) {
 	// Arrange
-	wr := InitRouter(nil)
+	wr := NewRouter(nil)
 
 	helloHandler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, resources.Hello)
@@ -310,12 +310,12 @@ func TestRouter_Walk_Error(t *testing.T) {
 		fmt.Fprintln(w, resources.Goodbye)
 	}
 
-	wh := InitHandler(nil).
+	wh := NewHandler(nil).
 		WithMethodHandler(http.MethodDelete, goodbyeHandler)
 
 	wr.Handle(resources.TestRoute, wh)
 
-	wh2 := InitHandler(nil).
+	wh2 := NewHandler(nil).
 		WithMethodHandler(http.MethodGet, helloHandler)
 
 	wr.Handle(resources.TestRouteThree, wh2)

--- a/waggy_test.go
+++ b/waggy_test.go
@@ -30,7 +30,7 @@ func TestLog(t *testing.T) {
 		assert.NotNil(t, l)
 	}
 
-	handler := InitHandlerWithRoute(resources.TestRoutePathParams, nil).
+	handler := NewHandlerWithRoute(resources.TestRoutePathParams, nil).
 		WithLogger(&logger, nil)
 
 	handler.WithMethodHandler(http.MethodGet, greetingHandler)
@@ -51,7 +51,7 @@ func TestLog_Error(t *testing.T) {
 		assert.Nil(t, l)
 	}
 
-	handler := InitHandlerWithRoute(resources.TestRoutePathParams, nil).
+	handler := NewHandlerWithRoute(resources.TestRoutePathParams, nil).
 		WithLogger(nil, nil)
 
 	handler.WithMethodHandler(http.MethodGet, greetingHandler)
@@ -79,7 +79,7 @@ func TestVars_Hello(t *testing.T) {
 		}
 	}
 
-	handler := InitHandlerWithRoute(resources.TestRoutePathParams, nil)
+	handler := NewHandlerWithRoute(resources.TestRoutePathParams, nil)
 
 	handler.WithMethodHandler(http.MethodGet, greetingHandler)
 
@@ -108,7 +108,7 @@ func TestVars_Goodbye(t *testing.T) {
 		}
 	}
 
-	handler := InitHandlerWithRoute(resources.TestRoutePathParams, nil)
+	handler := NewHandlerWithRoute(resources.TestRoutePathParams, nil)
 
 	handler.WithMethodHandler(http.MethodGet, greetingHandler)
 
@@ -139,7 +139,7 @@ func TestVars_NoPathParams(t *testing.T) {
 		}
 	}
 
-	handler := InitHandlerWithRoute(resources.TestRoute, nil)
+	handler := NewHandlerWithRoute(resources.TestRoute, nil)
 
 	handler.WithMethodHandler(http.MethodGet, greetingHandler)
 
@@ -161,7 +161,7 @@ func TestWriteDefaultResponse(t *testing.T) {
 		WriteDefaultResponse(w, r)
 	}
 
-	handler := InitHandlerWithRoute(resources.TestRoute, nil).
+	handler := NewHandlerWithRoute(resources.TestRoute, nil).
 		WithMethodHandler(http.MethodGet, defRespHandler).
 		WithDefaultResponse(resources.TestContentType, []byte(resources.Hello))
 
@@ -190,7 +190,7 @@ func TestWriteDefaultErrorResponse(t *testing.T) {
 		WriteDefaultErrorResponse(w, r)
 	}
 
-	handler := InitHandlerWithRoute(resources.TestRoute, nil).
+	handler := NewHandlerWithRoute(resources.TestRoute, nil).
 		WithMethodHandler(http.MethodGet, defRespHandler).
 		WithDefaultErrorResponse(testErr, http.StatusInternalServerError)
 
@@ -244,7 +244,7 @@ func TestServeFile_NoPathToFile(t *testing.T) {
 
 func TestServe_Router(t *testing.T) {
 	// Arrange
-	w := InitRouter(nil)
+	w := NewRouter(nil)
 
 	// Act
 	err := Serve(w)
@@ -255,7 +255,7 @@ func TestServe_Router(t *testing.T) {
 
 func TestServe_Handler(t *testing.T) {
 	// Arrange
-	w := InitHandler(nil)
+	w := NewHandler(nil)
 
 	// Act
 	err := Serve(w)
@@ -265,7 +265,7 @@ func TestServe_Handler(t *testing.T) {
 }
 
 func TestEmptyRoute(t *testing.T) {
-	handler := InitHandlerWithRoute("/", nil)
+	handler := NewHandlerWithRoute("/", nil)
 	handler.WithMethodHandler(http.MethodGet, func(writer http.ResponseWriter, request *http.Request) {
 		fmt.Fprintln(writer, "Don't panic! 🐿️")
 	})

--- a/waggy_test.go
+++ b/waggy_test.go
@@ -60,7 +60,7 @@ func TestServeThroughMiddleWare(t *testing.T) {
 		assert.Equal(t, "hello world", w.Header().Get("test"))
 	}
 
-	handler := InitHandlerWithRoute(resources.TestRoutePathParams, nil)
+	handler := NewHandlerWithRoute(resources.TestRoutePathParams, nil)
 
 	handler.WithMethodHandler(http.MethodGet, testHandler).
 		Use(testMiddleWareTest)

--- a/waggy_test.go
+++ b/waggy_test.go
@@ -3,7 +3,6 @@ package waggy
 import (
 	"fmt"
 	"github.com/syke99/waggy/internal/json"
-	"github.com/syke99/waggy/middleware"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -35,35 +34,6 @@ func TestLog(t *testing.T) {
 		WithLogger(&logger, nil)
 
 	handler.WithMethodHandler(http.MethodGet, greetingHandler)
-
-	r, _ := http.NewRequest(http.MethodGet, resources.TestRoutePathParamGoodbye, nil)
-
-	wr := httptest.NewRecorder()
-
-	handler.ServeHTTP(wr, r)
-}
-
-var testMiddleWareTest middleware.MiddleWare = func(handler http.Handler) http.Handler {
-	fn := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("test", "hello world")
-
-		handler.ServeHTTP(w, r)
-	}
-
-	return http.HandlerFunc(fn)
-}
-
-func TestServeThroughMiddleWare(t *testing.T) {
-	// Arrange
-	testHandler := func(w http.ResponseWriter, r *http.Request) {
-		// Assert
-		assert.Equal(t, "hello world", w.Header().Get("test"))
-	}
-
-	handler := NewHandlerWithRoute(resources.TestRoutePathParams, nil)
-
-	handler.WithMethodHandler(http.MethodGet, testHandler).
-		Use(testMiddleWareTest)
 
 	r, _ := http.NewRequest(http.MethodGet, resources.TestRoutePathParamGoodbye, nil)
 


### PR DESCRIPTION
This will correctly pass the handler, whether a *Handler or *Router, through the middleware (if any are set) before serving the handler